### PR TITLE
BI-2785: Fix table names > 128 characters causing invalid cursor in Power BI

### DIFF
--- a/libmysql/libmysql.c
+++ b/libmysql/libmysql.c
@@ -788,14 +788,14 @@ MYSQL_FIELD *cli_list_fields(MYSQL *mysql)
 MYSQL_RES * STDCALL
 mysql_list_fields(MYSQL *mysql, const char *table, const char *wild)
 {
-  #define TABLE_SIZE 65535
+  #define TABLE_NAME_SIZE 65535
   MYSQL_RES   *result;
   MYSQL_FIELD *fields;
-  char	     buff[TABLE_SIZE],*end;
+  char	     buff[TABLE_NAME_SIZE],*end;
   DBUG_ENTER("mysql_list_fields");
   DBUG_PRINT("enter",("table: '%s'  wild: '%s'",table,wild ? wild : ""));
 
-  end=strmake(strmake(buff, table,TABLE_SIZE)+1,wild ? wild : "",TABLE_SIZE);
+  end=strmake(strmake(buff, table,TABLE_NAME_SIZE)+1,wild ? wild : "",TABLE_NAME_SIZE);
   free_old_query(mysql);
   if (simple_command(mysql, COM_FIELD_LIST, (uchar*) buff,
                      (ulong) (end-buff), 1) ||

--- a/libmysql/libmysql.c
+++ b/libmysql/libmysql.c
@@ -791,7 +791,8 @@ mysql_list_fields(MYSQL *mysql, const char *table, const char *wild)
   #define TABLE_NAME_SIZE 65535
   MYSQL_RES   *result;
   MYSQL_FIELD *fields;
-  char	     buff[TABLE_NAME_SIZE],*end;
+  // the buffer must be 130 characters bigger than TABLE_NAME_SIZE.
+  char	     buff[65665],*end;
   DBUG_ENTER("mysql_list_fields");
   DBUG_PRINT("enter",("table: '%s'  wild: '%s'",table,wild ? wild : ""));
 

--- a/libmysql/libmysql.c
+++ b/libmysql/libmysql.c
@@ -788,13 +788,14 @@ MYSQL_FIELD *cli_list_fields(MYSQL *mysql)
 MYSQL_RES * STDCALL
 mysql_list_fields(MYSQL *mysql, const char *table, const char *wild)
 {
+  #define TABLE_SIZE 65535
   MYSQL_RES   *result;
   MYSQL_FIELD *fields;
-  char	     buff[258],*end;
+  char	     buff[TABLE_SIZE],*end;
   DBUG_ENTER("mysql_list_fields");
   DBUG_PRINT("enter",("table: '%s'  wild: '%s'",table,wild ? wild : ""));
 
-  end=strmake(strmake(buff, table,128)+1,wild ? wild : "",128);
+  end=strmake(strmake(buff, table,TABLE_SIZE)+1,wild ? wild : "",TABLE_SIZE);
   free_old_query(mysql);
   if (simple_command(mysql, COM_FIELD_LIST, (uchar*) buff,
                      (ulong) (end-buff), 1) ||

--- a/libmysql/libmysql.c
+++ b/libmysql/libmysql.c
@@ -788,15 +788,17 @@ MYSQL_FIELD *cli_list_fields(MYSQL *mysql)
 MYSQL_RES * STDCALL
 mysql_list_fields(MYSQL *mysql, const char *table, const char *wild)
 {
-  #define TABLE_NAME_SIZE 65535
+  #define MAX_TABLE_NAME_SIZE 65535
   MYSQL_RES   *result;
   MYSQL_FIELD *fields;
-  // the buffer must be 130 characters bigger than TABLE_NAME_SIZE.
+  // the buffer must be 130 characters bigger than MAX_TABLE_NAME_SIZE.
+  // the other characters are used for the COM_FIELD_LIST packet header and possible wild card added
+  // to the table name.
   char	     buff[65665],*end;
   DBUG_ENTER("mysql_list_fields");
   DBUG_PRINT("enter",("table: '%s'  wild: '%s'",table,wild ? wild : ""));
 
-  end=strmake(strmake(buff, table,TABLE_NAME_SIZE)+1,wild ? wild : "",TABLE_NAME_SIZE);
+  end=strmake(strmake(buff, table, MAX_TABLE_NAME_SIZE)+1, wild ? wild : "", MAX_TABLE_NAME_SIZE);
   free_old_query(mysql);
   if (simple_command(mysql, COM_FIELD_LIST, (uchar*) buff,
                      (ulong) (end-buff), 1) ||


### PR DESCRIPTION
This + the other fix I pushed to master by mistake should work to fix this issue up to 16K table names. I think 16K should be sufficient.

The other fix did not fix this issue because it was not the bottle neck. But after fixing this specifically here we would have ran into that 300ish + table_name_size size limit on the queries, so that previous push to master is still necessary.

NOTE: the only actual change to the driver we need here is to update the submodule.