### PR TITLE
HELP-49134: update table name limit to be smaller

### DIFF
--- a/include/mysql_com.h
+++ b/include/mysql_com.h
@@ -24,7 +24,7 @@
 #define HOSTNAME_LENGTH 60
 #define SYSTEM_CHARSET_MBMAXLEN 3
 #define FILENAME_CHARSET_MBMAXLEN 5
-#define NAME_CHAR_LEN	65536              /* Field/table name length */
+#define NAME_CHAR_LEN	2048              /* Field/table name length */
 #define USERNAME_CHAR_LENGTH 32
 #define USERNAME_CHAR_LENGTH_STR "32"
 #ifndef NAME_LEN

--- a/libmysql/libmysql.c
+++ b/libmysql/libmysql.c
@@ -788,13 +788,13 @@ MYSQL_FIELD *cli_list_fields(MYSQL *mysql)
 MYSQL_RES * STDCALL
 mysql_list_fields(MYSQL *mysql, const char *table, const char *wild)
 {
-  #define MAX_TABLE_NAME_SIZE 65535
+  #define MAX_TABLE_NAME_SIZE 2047
   MYSQL_RES   *result;
   MYSQL_FIELD *fields;
   // the buffer must be 130 characters bigger than MAX_TABLE_NAME_SIZE.
   // the other characters are used for the COM_FIELD_LIST packet header and possible wild card added
   // to the table name.
-  char	     buff[65665],*end;
+  char	     buff[2177],*end;
   DBUG_ENTER("mysql_list_fields");
   DBUG_PRINT("enter",("table: '%s'  wild: '%s'",table,wild ? wild : ""));
 


### PR DESCRIPTION
One note: for `MAX_TABLE_NAME_LEN`, we originally used 128, which was `NAME_CHAR_LEN` * 2, but when it became larger, it went to 65535 (`NAME_CHAR_LEN` - 1). I followed that convention but just wanted to flag since I noticed the diff.